### PR TITLE
Correct requirements for Symmetry Island laser

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -218,7 +218,7 @@
                 "item_count": 1
             },
 			{
-				"access_rules": ["@Places/symmetryInner, ColoredDots"],
+				"access_rules": ["@Places/symmetryInner,ColoredDots,Symmetry"],
                 "name": "Laser",
                 "item_count": 1
             },


### PR DESCRIPTION
Access rules incorrectly left out "Symmetry", so if you're playing a mode where `symmetryInner` is unlocked independently, the tracker would incorrectly think that laser was obtainable