### PR TITLE
Update Mountaintop River Panel to always appear

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -2788,7 +2788,7 @@
         "sections": [
             {
                 "name": "River Overlook Panel",
-				"visibility_rules": ["Unrandomized"],
+				"visibility_rules": [],
                 "item_count": 1
             },
             {


### PR DESCRIPTION
"mountaintop river shape" seems like it can contain items, even with "shuffle unrandomized" turned off.