### PR TITLE
Updated EPs for non-randomized and added one EP snipe

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -25,7 +25,7 @@
             {
                 "name": "Gate EP",
                 "access_rules": ["@Places/tutorial, Triangles, [@Mountain Challenge Area/Challenge Vault]"],
-                "visibility_rules": ["eps"],
+                "visibility_rules": ["eps, Unrandomized"],
                 "item_count": 1
             }
         ],
@@ -55,7 +55,7 @@
             {
                 "name": "Patio Flowers EP",
                 "access_rules": ["@Places/tutorial, $canSolve|158009-158010"],
-                "visibility_rules": ["eps"],
+                "visibility_rules": ["eps, Unrandomized"],
                 "item_count": 1
             },
             {
@@ -370,7 +370,7 @@
                 "item_count": 1
             },			
             {
-				"access_rules": ["@Places/symmetryInner"],
+				"access_rules": ["@Places/symmetryOuter, [@Places/symmetryInner]"],
                 "name": "Glass Factory Black Line EP",
 				"visibility_rules": ["eps"],
                 "item_count": 1
@@ -1411,19 +1411,19 @@
             {
                 "name": "Left Shutter EP",
 				"access_rules": ["@Places/monastery,$canSolve|158213"],
-				"visibility_rules": ["eps"],
+				"visibility_rules": ["eps, Unrandomized"],
                 "item_count": 1
             },
             {
                 "name": "Middle Shutter EP",
 				"access_rules": ["@Places/monastery,$canSolve|158213"],
-				"visibility_rules": ["eps"],
+				"visibility_rules": ["eps, Unrandomized"],
                 "item_count": 1
             },
             {
                 "name": "Right Shutter EP",
 				"access_rules": ["@Places/monastery,$canSolve|158213"],
-				"visibility_rules": ["eps"],
+				"visibility_rules": ["eps, Unrandomized"],
                 "item_count": 1
             }
         ],
@@ -1773,19 +1773,19 @@
             },
 			{
                 "name": "Window EP",
-				"visibility_rules": ["eps"],
+				"visibility_rules": ["eps, Unrandomized"],
 				"access_rules": ["@Theater/Tutorial Video"],
                 "item_count": 1
             },
 			{
                 "name": "Door EP",
-				"visibility_rules": ["eps"],
+				"visibility_rules": ["eps, Unrandomized"],
 				"access_rules": ["@Theater/Tutorial Video"],
                 "item_count": 1
             },
 			{
                 "name": "Flowers EP",
-				"visibility_rules": ["eps, epDiffTedious", "eps, epDiffEclipse"],
+				"visibility_rules": ["eps, epDiffTedious, Unrandomized", "eps, epDiffEclipse, Unrandomized"],
 				"access_rules": ["@Theater/Tutorial Video, @Places/tunnels", "epDiffNormal"],
                 "item_count": 1
             },
@@ -1803,7 +1803,7 @@
             },
 			{
                 "name": "Church EP",
-				"visibility_rules": ["eps"],
+				"visibility_rules": ["eps, Unrandomized"],
 				"access_rules": ["@Theater/Jungle Video"],
                 "item_count": 1
             },
@@ -1991,7 +1991,7 @@
             {
                 "name": "Garden Left EP",
 				"access_rules": ["Monastery Door to Garden", "Monastery Shortcuts","$isDoors|off, @Monastery/Outside Puzzles"],
-				"visibility_rules": ["eps"],
+				"visibility_rules": ["eps, Unrandomized"],
                 "item_count": 1
             },
             {


### PR DESCRIPTION
Changed Tutorial Gate EP, Tutorial Patio Flowers EP, Monastery Garden Left EP, Monastery Shutter EPs, and Theater EPs to not appear with disable_non_randomized. Added a snipe for Symmetry Island Black Line EP from on the first half of the island