### PR TITLE
Changing EP requirements and logic, isDoors, and isExpert

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -1817,7 +1817,7 @@
             },
 			{
                 "name": "Eclipse EP",
-				"visibility_rules": ["eps, epDiffEclipse"],
+				"visibility_rules": ["eps, epDiffEclipse, Unrandomized"],
 				"access_rules": ["@Theater/Challenge Video", "epDiffNormal", "epdiffTedious"],
                 "item_count": 1
             },

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -1580,7 +1580,7 @@
 			{
                 "name": "RGB Room Right",
 				"access_rules": ["$isExpert|off,$canSolve|158246,[$canSolve|158244],@Places/RGBHouseUpstairs",
-                                         "$isExpert|on,[$canSolve|158244],$canSolve|158245-158246"],
+                                         "$isExpert|on,[$canSolve|158244],$canSolve|158245-158246,@Places/RGBHouseUpstairs"],
 				"visibility_rules": [""],
                 "item_count": 1
             },

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -24,8 +24,8 @@
             },
             {
                 "name": "Gate EP",
-                "access_rules": ["@Places/tutorial, Triangles, [@Mountain Challenge Area/Challenge Vault]"],
-                "visibility_rules": ["eps"],
+                "access_rules": ["@Places/tutorial, Triangles, [@Places/tunnels]"],
+                "visibility_rules": ["eps, Unrandomized"],
                 "item_count": 1
             }
         ],
@@ -55,7 +55,7 @@
             {
                 "name": "Patio Flowers EP",
                 "access_rules": ["@Places/tutorial, $canSolve|158009-158010"],
-                "visibility_rules": ["eps"],
+                "visibility_rules": ["eps, Unrandomized"],
                 "item_count": 1
             },
             {
@@ -370,7 +370,7 @@
                 "item_count": 1
             },			
             {
-				"access_rules": ["@Places/symmetryInner"],
+				"access_rules": ["@Places/symmetryOuter, [@Places/symmetryInner]"],
                 "name": "Glass Factory Black Line EP",
 				"visibility_rules": ["eps"],
                 "item_count": 1
@@ -1411,19 +1411,19 @@
             {
                 "name": "Left Shutter EP",
 				"access_rules": ["@Places/monastery,$canSolve|158213"],
-				"visibility_rules": ["eps"],
+				"visibility_rules": ["eps, Unrandomized"],
                 "item_count": 1
             },
             {
                 "name": "Middle Shutter EP",
 				"access_rules": ["@Places/monastery,$canSolve|158213"],
-				"visibility_rules": ["eps"],
+				"visibility_rules": ["eps, Unrandomized"],
                 "item_count": 1
             },
             {
                 "name": "Right Shutter EP",
 				"access_rules": ["@Places/monastery,$canSolve|158213"],
-				"visibility_rules": ["eps"],
+				"visibility_rules": ["eps, Unrandomized"],
                 "item_count": 1
             }
         ],
@@ -1579,7 +1579,8 @@
             },
 			{
                 "name": "RGB Room Right",
-				"access_rules": ["$canSolve|158246,[$canSolve|158244],@Places/RGBHouseUpstairs"],
+				"access_rules": ["$isExpert|off,$canSolve|158246,[$canSolve|158244],@Places/RGBHouseUpstairs",
+                                         "$isExpert|on,[$canSolve|158244],$canSolve|158245-158246"],
 				"visibility_rules": [""],
                 "item_count": 1
             },
@@ -1598,7 +1599,8 @@
             },
 			{
                 "name": "RGB House Red EP",
-				"access_rules": ["$canSolve|158244,@Places/RGBHouseUpstairs"],
+				"access_rules": ["$isExpert|off,$canSolve|158244,@Places/RGBHouseUpstairs,@Places/redRoof",
+                                         "$isExpert|on,$canSolve|158244-158246,@Places/redRoof"],
 				"visibility_rules": ["eps"],
                 "item_count": 1
             },
@@ -1773,19 +1775,19 @@
             },
 			{
                 "name": "Window EP",
-				"visibility_rules": ["eps"],
+				"visibility_rules": ["eps, Unrandomized"],
 				"access_rules": ["@Theater/Tutorial Video"],
                 "item_count": 1
             },
 			{
                 "name": "Door EP",
-				"visibility_rules": ["eps"],
+				"visibility_rules": ["eps, Unrandomized"],
 				"access_rules": ["@Theater/Tutorial Video"],
                 "item_count": 1
             },
 			{
                 "name": "Flowers EP",
-				"visibility_rules": ["eps, epDiffTedious", "eps, epDiffEclipse"],
+				"visibility_rules": ["eps, epDiffTedious, Unrandomized", "eps, epDiffEclipse, Unrandomized"],
 				"access_rules": ["@Theater/Tutorial Video, @Places/tunnels", "epDiffNormal"],
                 "item_count": 1
             },
@@ -1803,7 +1805,7 @@
             },
 			{
                 "name": "Church EP",
-				"visibility_rules": ["eps"],
+				"visibility_rules": ["eps, Unrandomized"],
 				"access_rules": ["@Theater/Jungle Video"],
                 "item_count": 1
             },
@@ -1991,7 +1993,7 @@
             {
                 "name": "Garden Left EP",
 				"access_rules": ["Monastery Door to Garden", "Monastery Shortcuts","$isDoors|off, @Monastery/Outside Puzzles"],
-				"visibility_rules": ["eps"],
+				"visibility_rules": ["eps, Unrandomized"],
                 "item_count": 1
             },
             {
@@ -2792,7 +2794,7 @@
         "sections": [
             {
                 "name": "River Overlook Panel",
-				"visibility_rules": ["Unrandomized"],
+				"visibility_rules": [""],
                 "item_count": 1
             },
             {
@@ -2810,7 +2812,7 @@
             {
                 "name": "Mountain Entry",
 				"access_rules": ["$canSolve|158407,$laserBox|short"],
-				"visibility_rules": [],
+				"visibility_rules": [""],
                 "item_count": 1
             },
             {
@@ -2998,7 +3000,7 @@
 
 	{
         "name": "Caves Lower Puzzles",
-		"access_rules": [],
+		"access_rules": [""],
         "sections": [
             {
                 "name": "Right First 4",
@@ -3228,7 +3230,7 @@
 			{
                 "name": "Challenge Vault",
 				"access_rules": ["$canSolve|158499-158517,$laserBox|long"],
-				"visibility_rules": [],
+				"visibility_rules": [""],
                 "item_count": 1
             }
         ],

--- a/scripts/logic.lua
+++ b/scripts/logic.lua
@@ -4,29 +4,18 @@ end
 
 function isDoors(check)
 	if check == "on" then
-		result = (Tracker:ProviderCountForCode("doorsSimple") + Tracker:ProviderCountForCode("doorsComplex") + Tracker:ProviderCountForCode("doorsMax"))
+		return (Tracker:ProviderCountForCode("doorsSimple") + Tracker:ProviderCountForCode("doorsComplex") + Tracker:ProviderCountForCode("doorsMax") > 0)
 	else
-		result = (Tracker:ProviderCountForCode("doorsNo") + Tracker:ProviderCountForCode("doorsPanel")) 
-	end 
-	return result
-end
-
-function isLaserShuffle(check)
-	if check == "on" then
-		result = Tracker:ProviderCountForCode("shuffleLasers")
-	else
-		result = 1 - Tracker:ProviderCountForCode("shuffleLasers")
-	end 
-	return result
+		return (Tracker:ProviderCountForCode("doorsNo") + Tracker:ProviderCountForCode("doorsPanel") > 0) 
+	end
 end
 
 function isExpert(check)
 	if check == "on" then
-		result = Tracker:ProviderCountForCode("Expert")
+		return (Tracker:ProviderCountForCode("Expert") > 0)
 	else
-		result = 1 - Tracker:ProviderCountForCode("Expert")
-	end 
-	return result
+		return (1 - Tracker:ProviderCountForCode("Expert") > 0)
+	end
 end
 
 function laserCount(amount)
@@ -64,7 +53,6 @@ function pp2()
 	return (isExpert("off") or (isDoors("off") and canSolve("158198 158200 158202 158204")) or
 	(isDoors("on") and 
 	Tracker:ProviderCountForCode("Keep Pressure Plates 1 Exit Door") == 1 and
-	Tracker:ProviderCountForCode("Keep Pressure Plates 2 Exit Door") == 1 and
 	Tracker:ProviderCountForCode("Keep Pressure Plates 3 Exit Door") == 1 and
 	(Tracker:ProviderCountForCode("Keep Shortcut to Shadows") == 1 or
 	(Tracker:ProviderCountForCode("Keep Pressure Plates 4 Exit Door") == 1 and


### PR DESCRIPTION
Changed isDoors and isExpert to return flat true/false values.
Removed isLaserShuffle (never used anywhere).
Removed a line from PP2 check (PP2 Exit Door is never required, or useful).

Updated non-randomized EPs to not show up with non-randomized (Tutorial Gate and Patio Flowers, Theater EPs, Monastery Garden Left, Monastery Shutters)
Updated Gate EP logic to require tunnels vault and not challenge vault.
Updated RGB room panels for expert logic.
Updated Town Red Flowers to require maze roof.
Added snipe for Symmetry Island Black Line EP.
Prevented River Overlook Panel from being disabled with non-randomized.
Added blank "" to some empty sets.