### PR TITLE
Fix some EP logic and Quarry Boathouse Back logic

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -1262,7 +1262,7 @@
 			{
                 "name": "Boathouse Moving Ramp EP",
 				"access_rules": ["$isDoors|off, @Logic/boathouseRamp, $canSolve|158148, $canSolve|158154, $hasPanel|Quarry Boathouse Ramp Horizontal Control (Panel), @Quarry Boathouse/Front Row",
-                    "$isDoors|on, @Logic/boathouseRamp, $canSolve|158148, $canSolve|158154, $hasPanel|Quarry Boathouse Ramp Horizontal Control (Panel), Quarry Boathouse First Barrier"],
+                    "$isDoors|on, @Logic/boathouseRamp, $canSolve|158148, $canSolve|158154, $hasPanel|Quarry Boathouse Ramp Horizontal Control (Panel), Quarry Boathouse First Barrier, Quarry Boathouse Shortcut"],
 				"visibility_rules": ["eps"],
                 "item_count": 1
             }
@@ -1290,7 +1290,7 @@
 			{
                 "name": "Boathouse Moving Ramp EP (Quarry Side 1)",
 				"access_rules": ["$isDoors|off, @Logic/boathouseRamp, $canSolve|158148, $canSolve|158154, $hasPanel|Quarry Boathouse Ramp Horizontal Control (Panel), @Quarry Boathouse/Front Row",
-                    "$isDoors|on, @Logic/boathouseRamp, $canSolve|158148, $canSolve|158154, $hasPanel|Quarry Boathouse Ramp Horizontal Control (Panel), Quarry Boathouse First Barrier"],
+                    "$isDoors|on, @Logic/boathouseRamp, $canSolve|158148, $canSolve|158154, $hasPanel|Quarry Boathouse Ramp Horizontal Control (Panel), Quarry Boathouse First Barrier, Quarry Boathouse Shortcut"],
 				"visibility_rules": ["obelisks"],
                 "item_count": 1
             }

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -1254,7 +1254,8 @@
             },			
 			{
                 "name": "Boathouse Hook EP",
-				"access_rules": ["$isDoors|off, @Places/quarryBoathouseUpstairsBack"],
+				"access_rules": ["$isDoors|off, @Places/quarryBoathouseUpstairsBack",
+						"$isDoors|on, @Places/quarryBoathouseUpstairsBack, Quarry Boathouse Shortcut"],
 				"visibility_rules": ["eps"],
                 "item_count": 1
             },			
@@ -1281,7 +1282,8 @@
         "sections": [
 			{
                 "name": "Boathouse Hook EP (Quarry Side 1)",
-				"access_rules": ["$isDoors|off, @Places/quarryBoathouseUpstairsBack"],
+				"access_rules": ["$isDoors|off, @Places/quarryBoathouseUpstairsBack",
+						"$isDoors|on, @Places/quarryBoathouseUpstairsBack, Quarry Boathouse Shortcut"],
 				"visibility_rules": ["obelisks"],
                 "item_count": 1
             },			

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -490,7 +490,8 @@
 			{
                 "name": "Vase EP",
 				"visibility_rules": ["eps"],
-				"access_rules": ["$canSolve|158027, @Places/overworld"],
+				"access_rules": ["$isDoors|off, $canSolve|158027, @Places/overworld, $hasPanel|Glass Factory Entry Door (Panel)",
+						 "$isDoors|on, $canSolve|158027, @Places/overworld"],
                 "item_count": 1
             }
 			
@@ -508,7 +509,8 @@
         "sections": [
 			{
                 "name": "Vase EP (Desert Side 1)",
-				"visibility_rules": ["obelisks"],
+				"access_rules": ["$isDoors|off, $canSolve|158027, @Places/overworld, $hasPanel|Glass Factory Entry Door (Panel)",
+						 "$isDoors|on, $canSolve|158027, @Places/overworld"],
 				"access_rules": ["$canSolve|158027, @Places/overworld"],
                 "item_count": 1
             }

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -1722,7 +1722,8 @@
             },
             {
                 "name": "Pressure Plates 3 EP",
-				"access_rules": ["@Pressure Plates 3/Pressure Plates, @Places/keepTower"],
+				"access_rules": ["$isDoors|off, @Pressure Plates 3/Pressure Plates, @Places/keepTower",
+						 "$isDoors|on, Keep Pressure Plates 3 Exit Door, @Pressure Plates 3/Pressure Plates, @Places/keepTower"],
 				"visibility_rules": ["eps"],
                 "item_count": 1
             }
@@ -1819,7 +1820,8 @@
         "sections": [
             {
                 "name": "Pressure Plates 3 EP (Treehouse Side 5)",
-				"access_rules": ["@Pressure Plates 3/Pressure Plates, @Places/keepTower"],
+				"access_rules": ["$isDoors|off, @Pressure Plates 3/Pressure Plates, @Places/keepTower",
+						 "$isDoors|on, Keep Pressure Plates 3 Exit Door, @Pressure Plates 3/Pressure Plates, @Places/keepTower"],
 				"visibility_rules": ["obelisks"],
                 "item_count": 1
             }
@@ -2374,8 +2376,10 @@
             },
 			{
                 "name": "RGB House Red EP",
-				"access_rules": ["$isExpert|off,$canSolve|158244,@Places/RGBHouseUpstairs,@Places/redRoof",
-                                         "$isExpert|on,$canSolve|158244-158246,@Places/redRoof"],
+                                "access_rules": ["$isDoors|off,$hasPanel|Town Maze Panel (Drop-Down Staircase) (Panel),$isExpert|off,$canSolve|158244,@Places/RGBHouseUpstairs",
+                                "$isDoors|on,Town Maze Staircase,$isExpert|off,$canSolve|158244,@Places/RGBHouseUpstairs",
+                                "$isDoors|off,$hasPanel|Town Maze Panel (Drop-Down Staircase) (Panel),$isExpert|on,$canSolve|158244-158246,@Places/RGBHouseUpstairs",
+                                "$isDoors|on,Town Maze Staircase,$isExpert|on,$canSolve|158244-158246,@Places/RGBHouseUpstairs"],
 				"visibility_rules": ["eps"],
                 "item_count": 1
             },
@@ -2398,9 +2402,11 @@
         "name": "RGB House EPs",
         "sections": [
 			{
-                "name": "RGB House Red EP (Town Side 5)",				
-                "access_rules": ["$isExpert|off,$canSolve|158244,@Places/RGBHouseUpstairs,@Places/redRoof",
-                                         "$isExpert|on,$canSolve|158244-158246,@Places/redRoof"],
+                "name": "RGB House Red EP (Town Side 5)",
+                                "access_rules": ["$isDoors|off,$hasPanel|Town Maze Panel (Drop-Down Staircase) (Panel),$isExpert|off,$canSolve|158244,@Places/RGBHouseUpstairs",
+                                "$isDoors|on,Town Maze Staircase,$isExpert|off,$canSolve|158244,@Places/RGBHouseUpstairs",
+                                "$isDoors|off,$hasPanel|Town Maze Panel (Drop-Down Staircase) (Panel),$isExpert|on,$canSolve|158244-158246,@Places/RGBHouseUpstairs",
+                                "$isDoors|on,Town Maze Staircase,$isExpert|on,$canSolve|158244-158246,@Places/RGBHouseUpstairs"],
 				"visibility_rules": ["obelisks"],
                 "item_count": 1
             },

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -490,8 +490,7 @@
 			{
                 "name": "Vase EP",
 				"visibility_rules": ["eps"],
-				"access_rules": ["$isDoors|off, $canSolve|158027, @Places/overworld, $hasPanel|Glass Factory Entry Door (Panel)",
-						 "$isDoors|on, $canSolve|158027, @Places/overworld"],
+				"access_rules": ["$canSolve|158027, @Places/overworld, $hasPanel|Glass Factory Entry Door (Panel)"],
                 "item_count": 1
             }
 			
@@ -509,8 +508,7 @@
         "sections": [
 			{
                 "name": "Vase EP (Desert Side 1)",
-				"access_rules": ["$isDoors|off, $canSolve|158027, @Places/overworld, $hasPanel|Glass Factory Entry Door (Panel)",
-						 "$isDoors|on, $canSolve|158027, @Places/overworld"],
+				"access_rules": ["$canSolve|158027, @Places/overworld, $hasPanel|Glass Factory Entry Door (Panel)"],
 				"access_rules": ["$canSolve|158027, @Places/overworld"],
                 "item_count": 1
             }

--- a/locations/logic.json
+++ b/locations/logic.json
@@ -154,7 +154,7 @@
       {
         "name": "quarryBoathouseUpstairsBack",
         "access_rules": [
-			"$isDoors|off, @Places/quarryBoathouseUpstairsFront, $canSolve|158154, [$hasPanel|Quarry Boathouse Ramp Horizontal Control (Panel)]",
+			"$isDoors|off, @Places/quarryBoathouseUpstairsFront, $canSolve|158149-158153, [$hasPanel|Quarry Boathouse Ramp Horizontal Control (Panel)]",
 			"$isDoors|on, @Places/quarryBoathouseUpstairsFront, Quarry Boathouse First Barrier, Quarry Boathouse Shortcut",
 			"$isDoors|on, @Places/quarryBoathouseUpstairsFront, $canSolve|158154, Quarry Boathouse First Barrier, $hasPanel|Quarry Boathouse Ramp Horizontal Control (Panel)"
 		],


### PR DESCRIPTION
Quarry Boathouse Hook EP - Added doors logic with Second Barrier requirement.
Quarry Boathouse Moving Ramp EP - Requires Second Barrier or you can lock the ramp in the wrong spot.
Keep Pressure Plates 3 EP - Added PP3 Exit Door requirement.
Town RGB House Red EP - Fixed logic, again. It relies on expert/normal and doors/non-doors so it's long.
Glass Factory Vase EP - Require the door panel for Panels mode

Fixed Quarry Back half logic in non-doors to require solving the five panels that activate the first Barrier and not the one panel on the floor.