### PR TITLE
Case fix for Linux compatibility

### DIFF
--- a/locations/paths.json
+++ b/locations/paths.json
@@ -1,7 +1,7 @@
 [
 	{
 		"name": "Paths",
-		"chest_opened_img": "images/door.png",
+		"chest_opened_img": "images/Door.png",
 		"chest_unopened_img": "images/disabledDoor.png",
 		"children": [
 			{


### PR DESCRIPTION
The `images/Door.png` file is specified in the `locations/paths.json` file with a different casing to how the file is stored in git, resulting in not being able to display that image in Linux (instead being shown by the open chest icon rather than an unlocked padlock). This fixes the JSON to use the casing used elsewhere in the project.